### PR TITLE
adapt to new docker_client() API

### DIFF
--- a/construi/target.py
+++ b/construi/target.py
@@ -8,6 +8,7 @@ from compose.service import ConvergenceStrategy
 import dockerpty
 import random
 import sys
+import os
 
 
 def generate_build_id():
@@ -23,7 +24,7 @@ class Target(object):
         self.project = Project.from_config(
             "construi_%s" % Target.build_id(),
             config.compose,
-            docker_client())
+            docker_client(os.environ))
 
     @classmethod
     def build_id(cls):


### PR DESCRIPTION
docker-compose 1.7 has changed the API of docker_client(), need at least an environment as its first parameter.