### PR TITLE
Fix six version issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,8 @@ def find_version():
 requires = {
     'install': [
         'PyYAML == 3.11',
-        'docker-compose == 1.8.1'
+        'docker-compose == 1.8.1',
+        'six == 1.10.0'
     ],
     'setup': [
         'flake8 == 3.0.4',


### PR DESCRIPTION
With specifying six version under `1.5`, I got this error:

```
Traceback (most recent call last):
  File "/usr/local/bin/construi", line 9, in <module>
    load_entry_point('construi==40', 'console_scripts', 'construi')()
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python/pkg_resources/__init__.py", line 565, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python/pkg_resources/__init__.py", line 2697, in load_entry_point
    return ep.load()
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python/pkg_resources/__init__.py", line 2370, in load
    return self.resolve()
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python/pkg_resources/__init__.py", line 2376, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/Library/Python/2.7/site-packages/construi/cli.py", line 2, in <module>
    from .target import RunContext
  File "/Library/Python/2.7/site-packages/construi/target.py", line 3, in <module>
    from compose.project import Project
  File "/Library/Python/2.7/site-packages/compose/project.py", line 12, in <module>
    from . import parallel
  File "/Library/Python/2.7/site-packages/compose/parallel.py", line 10, in <module>
    from six.moves import _thread as thread
ImportError: cannot import name _thread
```

Related issue: https://github.com/dateutil/dateutil/issues/6

So my fix is to make sure `construi` uses latest `six`.