### PR TITLE
Add support for running multiple targets

### DIFF
--- a/construi/target.py
+++ b/construi/target.py
@@ -15,8 +15,7 @@ class Target(object):
         self.config = config
         self.project = Project.from_config(
             "construi_%s" % self.config.construi['project_name'],
-            config.compose,
-            docker_client(os.environ))
+            config.compose, docker_client(os.environ))
 
     @property
     def before(self):


### PR DESCRIPTION
There are times we want to run multiple targets instead of just one target. I know we can do this by updating `construi.yml`, but if this is a one-time command, updating `construi.yml` is redundant then.

So we need this feature to run multiple targets with `cli`