### PR TITLE
Refactoring of build failure.

### DIFF
--- a/construi/cli.py
+++ b/construi/cli.py
@@ -1,6 +1,5 @@
 from .config import parse, NoSuchTargetException
-from .target import RunContext
-from .target import Target
+from .target import BuildFailedException, RunContext, Target
 from .__version__ import __version__
 
 from argparse import ArgumentParser
@@ -31,6 +30,9 @@ def main():
     try:
         Target(config.for_target(target)).invoke(
             RunContext(config, args.dry_run))
+    except BuildFailedException:
+        console.error("\nBuild Failed.\n")
+        sys.exit(1)
     except NoSuchTargetException, e:
         console.error("\nNo such target: {}\n".format(e.target))
         sys.exit(1)
@@ -38,6 +40,11 @@ def main():
         console.error("\nUnexpected Error: {}\n".format(e.msg))
         traceback.print_exc()
         sys.exit(1)
+    except KeyboardInterrupt:
+        console.warn("\nBuild Interrupted.")
+        sys.exit(1)
+
+    console.info("\nBuild Succeeded.\n")
 
 
 def setup_logging():

--- a/construi/target.py
+++ b/construi/target.py
@@ -10,6 +10,11 @@ import os
 import os.path
 
 
+class BuildFailedException(Exception):
+    def __init__(self):
+        pass
+
+
 class Target(object):
     def __init__(self, config):
         self.config = config
@@ -71,10 +76,6 @@ class Target(object):
 
             console.progress('Done.')
 
-        except KeyboardInterrupt:
-            console.warn("\nBuild Interrupted.")
-            sys.exit(1)
-
         finally:
             self.cleanup()
 
@@ -92,7 +93,7 @@ class Target(object):
             dockerpty.start(self.client, container.id, interactive=False)
 
             if container.wait() != 0:
-                console.error("\nBuild Failed.")
+                raise BuildFailedException()
                 sys.exit(1)
 
         finally:


### PR DESCRIPTION
Use an exception instead of exiting on target failure.
Refactor all exception handling towards top level.
Print Build Suceeded on build success